### PR TITLE
Fix visit_orr error: name 'output' not defined

### DIFF
--- a/daidepp/parser/node_visitor.py
+++ b/daidepp/parser/node_visitor.py
@@ -194,7 +194,7 @@ class DaideVisitor(NodeVisitor):
         for par_arr in par_arrangements:
             _, arr, _ = par_arr
             print("arr", arr)
-            output["ORR"].append(arr)
+            arr_list.append(arr)
 
         return ("ORR", arr_list)
 


### PR DESCRIPTION
Fix error with visit_orr using output when output is not defined.