### PR TITLE
Make utility bounds arrangements instead of press_message

### DIFF
--- a/daide-specification.md
+++ b/daide-specification.md
@@ -959,10 +959,17 @@ Utility upper bound of float for power.
 Float is a floating point number in a format typically used by programming languages. It is currently parsed with the following regular expression:
 [-+]?((\d*\\.\d+)|(\d+\\.?))([Ee][+-]?\d+)?
 
+Strategy Robot Note: We intend to use INS to indicate active punishment or reward (changing our move to enfore the utility bound). In contrast, PRP indicates that we predict the utility bound is correct without our active enforcement.
+
 Example message sent from England to Germany:
 > IFF (XDO((GER AMY BER) MTO MUN)) THN (PRP (ULB (GER 0.8))) ELS (INS (UUB (GER 0.1)))
 
-This is a threat from England to Germany that says if you move BER to MUN then I will move to give you at least 0.8 utility, but if you do anything else I will move to prevent you from getting more than 0.1 utility.
+This is a threat from England to Germany that says if you move BER to MUN then I predict you will get at least 0.8 utility, but if you do anything else I will move to prevent you from getting more than 0.1 utility. In this case we are actively punishing Germany.
+
+Example message sent from England to Germany:
+> IFF (XDO((GER AMY BER) MTO MUN)) THN (PRP (ULB (GER 0.8))) ELS (PRP (UUB (GER 0.3)))
+
+This is a threat from England to Germany that says if you move BER to MUN then I predict you will get at least 0.8 utility, but if you do anything else I will predict you will get at most 0.3 utility. In this case we are not actively punishing or rewarding, we are just sharing the results of our game theory analysis.
 
 ## Level 8000: Free Text Press
 

--- a/src/daidepp/grammar/grammar.py
+++ b/src/daidepp/grammar/grammar.py
@@ -203,7 +203,7 @@ LEVEL_160: GrammarDict = {
     "float": 'ws*~"[-+]?((\d*\.\d+)|(\d+\.?))([Ee][+-]?\d+)?"',
     "ulb": '"ULB" lpar power float rpar',
     "uub": '"UUB" lpar power float rpar',
-    "press_message": f"{TRAIL_TOKEN}ulb / uub",
+    "arrangement": f"{TRAIL_TOKEN}ulb / uub",
     "try_tokens": f'{TRAIL_TOKEN}"ULB" / "UUB"',
 }
 


### PR DESCRIPTION
We intend to use propose (PRP) around utility bounds that result from the default equilibrium and insist (INS) for bounds resulting from active punishment. By active punishment, we mean that we plan to deliberately play an equilibrium that gives us less than maximum utility to lower your utility as punishment for disobeying our equilibrium in the previous turn.

We also plan to include a lower utility bound (reward) in our original move proposal message in some situations.

Unfortunately, we cannot use PRP or INS around utility bounds when they are press_messages. We also cannot use them inside AND which makes it impossible to include a utility bound in our move proposal message. Therefore, I changed utility bounds from press_message to arrangement to allow these uses.

I also modified the markdown to document our intended meanings for PRP and INS. 