### PR TITLE
Feat: add protocol token

### DIFF
--- a/daide-specification.md
+++ b/daide-specification.md
@@ -24,6 +24,7 @@ The syntax is split into a number of levels. Each level completely includes all 
 [Level 140: Sending Emotional State](#level-140-sending-emotional-state)  
 [Level 150: Requesting and Demanding Offer](#level-150-requesting-and-demanding-offer)  
 [Level 160: Utility Bounds](#level-160-utility-bounds)  
+[Level 170: Protocol Start](#level-170-protocol-start)  
 
 All Bots must implement the commands in all levels – they should not assume that they will never be playing in a game that is above the level they are designed for. Where a Bot receives a message that is above its intended level, there is a response it can use to indicate this.
 
@@ -970,6 +971,30 @@ Example message sent from England to Germany:
 > IFF (XDO((GER AMY BER) MTO MUN)) THN (PRP (ULB (GER 0.8))) ELS (PRP (UUB (GER 0.3)))
 
 This is a threat from England to Germany that says if you move BER to MUN then I predict you will get at least 0.8 utility, but if you do anything else I will predict you will get at most 0.3 utility. In this case we are not actively punishing or rewarding, we are just sharing the results of our game theory analysis.
+
+## Level 170: Protocol Start
+
+Level 170 adds the ability to request a specified set of powers to start a predefined protocol. It is intended to allow powers to agree to use protocols with specific requirements or changed interpretations of DAIDE while cleanly falling back to regular DAIDE if the protocol is not supported.
+
+> **arrangement = PTC int (power power ...)**
+
+Start protocol (identified by int) with listed powers. In most cases this power list should include the sender to indicate that the sender will participate in the protocol.
+
+The following table lists currently used protocol numbers, a brief explanation, and who created the protocol. Please update this table anytime you create a protocol so we avoid colliding protocol numbers.
+
+|   Protocol Number | Created By     | Brief Explanation |
+| ----------------: | :------------  | :---------------- |
+| 1                 | Strategy Robot | 3-way negotiation |
+
+Example message sent from England to Germany and France:
+> PRP(PTC 1 (ENG GER FRA))
+
+This message asks Germany and France to start using protocol 1 with Germany, France, and England.
+
+A power indicates that it understands and will participate in this protocol by replying YES (within some timeout).
+> YES(PRP(PTC 1 (ENG GER FRA)))
+
+Any other response (REJ, HUH, ignoring the message, etc) is assumed to indicate that this power will not participate in the protocol.
 
 ## Level 8000: Free Text Press
 

--- a/src/daidepp/grammar/grammar.py
+++ b/src/daidepp/grammar/grammar.py
@@ -9,7 +9,7 @@ from typing import Dict, Tuple
 from typing_extensions import Literal
 
 DAIDELevel = Literal[
-    0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160
+    0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170
 ]
 
 TRAIL_TOKEN = "---"  # any value starting with '---' is meant to be a continuation of that key, not a replacement
@@ -208,6 +208,15 @@ LEVEL_160: GrammarDict = {
     "try_tokens": f'{TRAIL_TOKEN}"ULB" / "UUB"',
 }
 
+# Protocol Start
+LEVEL_170: GrammarDict = {
+    "int": 'ws*~"\d+"',
+    "ptc": '"PTC" int lpar power (ws power)* rpar',
+    "sub_arrangement": f"{TRAIL_TOKEN}ptc",
+    "arrangement": f"{TRAIL_TOKEN}ptc",
+    "try_tokens": f'{TRAIL_TOKEN}"PTC"',
+}
+
 LEVELS: Tuple[GrammarDict, ...] = (
     LEVEL_0,
     LEVEL_10,
@@ -226,6 +235,7 @@ LEVELS: Tuple[GrammarDict, ...] = (
     LEVEL_140,
     LEVEL_150,
     LEVEL_160,
+    LEVEL_170,
 )
 
 GrammarDict = Dict[str, str]

--- a/src/daidepp/keywords/press_keywords.py
+++ b/src/daidepp/keywords/press_keywords.py
@@ -645,13 +645,20 @@ class UUB(_DAIDEObject):
     def __str__(self):
         return f"UUB ( {self.power} {self.float_val} )"
 
-@dataclass
-class PTC:
+
+@dataclass(eq=True, frozen=True)
+class PTC(_DAIDEObject):
     int_val: int
-    powers: List[Power]
+    powers: Tuple[Power]
+
+    def __init__(self, int_val: int, powers: Iterable[Power]):
+        object.__setattr__(self, "int_val", int_val)
+        object.__setattr__(self, "powers", tuple(sorted(set(powers))))
+        self.__post_init__()
 
     def __str__(self):
         return f"PTC {self.int_val} ( " + " ".join(self.powers) + " )"
+
 
 Reply = Union[YES, REJ, BWX, HUH, FCT, THK, IDK, WHY, POB, UHY, HPY, ANG]
 PressMessage = Union[

--- a/src/daidepp/keywords/press_keywords.py
+++ b/src/daidepp/keywords/press_keywords.py
@@ -515,6 +515,13 @@ class UUB:
     def __str__(self):
         return f"UUB ( {self.power} {self.float_val} )"
 
+@dataclass
+class PTC:
+    int_val: int
+    powers: List[Power]
+
+    def __str__(self):
+        return f"PTC {self.int_val} ( " + " ".join(self.powers) + " )"
 
 Reply = Union[YES, REJ, BWX, HUH, FCT, THK, IDK, WHY, POB, UHY, HPY, ANG]
 PressMessage = Union[
@@ -552,6 +559,7 @@ Arrangement = Union[
     ULB,
     UUB,
     ROF,
+    PTC,
 ]
 
 AnyDAIDEToken = Union[
@@ -611,4 +619,5 @@ AnyDAIDEToken = Union[
     ROF,
     ULB,
     UUB,
+    PTC,
 ]

--- a/src/daidepp/visitor.py
+++ b/src/daidepp/visitor.py
@@ -510,5 +510,17 @@ class DAIDEVisitor(NodeVisitor):
         _, _, power, utility, _ = visited_children
         return UUB(power, utility)
 
+    def visit_int(self, node, visited_children) -> float:
+        return int(visited_children[1].text)
+
+    def visit_ptc(self, node, visited_children) -> PTC:
+        _, int_val, _, power, more_powers, _ = visited_children
+
+        powers = [power]
+        for next_power in more_powers:
+            _, next_pow = next_power
+            powers.append(next_pow)
+        return PTC(int_val, powers)
+
 
 daide_visitor = DAIDEVisitor()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,6 +251,14 @@ def level_160_messages():
 
 
 @pytest.fixture
+def level_170_messages():
+    return [
+        "PTC 1 (ENG)",
+        "PTC 2432 (RUS GER)",
+    ]
+
+
+@pytest.fixture
 def bad_messages():
     return [
         "PRP (ENNG GER)",

--- a/tests/grammar/test_grammar.py
+++ b/tests/grammar/test_grammar.py
@@ -126,6 +126,12 @@ def test_level_160_messages(grammar, level_160_messages):
         grammar.parse(message)
 
 
+@pytest.mark.parametrize("grammar", [170], indirect=True)
+def test_level_170_messages(grammar, level_170_messages):
+    for message in level_170_messages:
+        grammar.parse(message)
+
+
 @pytest.mark.parametrize("grammar", [160], indirect=True)
 def test_bad_messages(grammar, bad_messages):
     with pytest.raises(ParseError):

--- a/tests/keywords/test_press_keywords.py
+++ b/tests/keywords/test_press_keywords.py
@@ -740,3 +740,15 @@ def test_ULB(input, expected_output):
 def test_UUB(input, expected_output):
     uub = UUB(*input)
     assert str(uub) == expected_output
+
+
+@pytest.mark.parametrize(
+    ["input", "expected_output"],
+    [
+        ((1, ["ENG", "GER"]), "PTC 1 ( ENG GER )"),
+        ((234, ["RUS", "GER", "FRA"]), "PTC 234 ( RUS GER FRA )"),
+    ],
+)
+def test_PTC(input, expected_output):
+    ptc = PTC(*input)
+    assert str(ptc) == expected_output

--- a/tests/keywords/test_press_keywords.py
+++ b/tests/keywords/test_press_keywords.py
@@ -832,7 +832,7 @@ def test_UUB(input, expected_output):
     ["input", "expected_output"],
     [
         ((1, ["ENG", "GER"]), "PTC 1 ( ENG GER )"),
-        ((234, ["RUS", "GER", "FRA"]), "PTC 234 ( RUS GER FRA )"),
+        ((234, ["RUS", "GER", "FRA"]), "PTC 234 ( FRA GER RUS )"),
     ],
 )
 def test_PTC(input, expected_output):

--- a/tests/test_daide_visitor.py
+++ b/tests/test_daide_visitor.py
@@ -6,7 +6,7 @@ from daidepp.grammar import create_daide_grammar
 from daidepp.keywords import *
 from daidepp.visitor import daide_visitor
 
-grammar = create_daide_grammar(level=170, string_type="all")
+grammar = create_daide_grammar(level=130, string_type="all")
 
 
 def test_basic_visitor(sample_daide_messages: List[str]):
@@ -39,7 +39,6 @@ def test_basic_visitor(sample_daide_messages: List[str]):
         ("SCD (FRA HOL)", SCD),
         ("SCD (AUS ANK BEL BER) (GER BRE BUD BUL DEN)", SCD),
         ("SCD (AUS ANK BEL BER) (GER BRE BUD BUL DEN) (FRA GRE HOL KIE)", SCD),
-        ("PTC 1 (ENG GER)", PTC),
     ],
 )
 def test_visitor_objects(daide_message: str, expected_type: AnyDAIDEToken):

--- a/tests/test_daide_visitor.py
+++ b/tests/test_daide_visitor.py
@@ -6,7 +6,7 @@ from daidepp.grammar import create_daide_grammar
 from daidepp.keywords import *
 from daidepp.visitor import daide_visitor
 
-grammar = create_daide_grammar(level=130, string_type="all")
+grammar = create_daide_grammar(level=170, string_type="all")
 
 
 def test_basic_visitor(sample_daide_messages: List[str]):
@@ -39,6 +39,7 @@ def test_basic_visitor(sample_daide_messages: List[str]):
         ("SCD (FRA HOL)", SCD),
         ("SCD (AUS ANK BEL BER) (GER BRE BUD BUL DEN)", SCD),
         ("SCD (AUS ANK BEL BER) (GER BRE BUD BUL DEN) (FRA GRE HOL KIE)", SCD),
+        ("PTC 1 (ENG GER)", PTC),
     ],
 )
 def test_visitor_objects(daide_message: str, expected_type: AnyDAIDEToken):


### PR DESCRIPTION
**What functionality will your new tokens add?**
Adds protocol token to request a specified set of powers to start a predefined protocol and provide a mechanism for powers to say they do not support the requested protocol.

**Describe the precise changes you'd like**
> **arrangement = PTC int (power power ...)**

Start protocol (identified by int) with listed powers. In most cases this power list should include the sender to indicate that the sender will participate in the protocol.
This token is added in a new level 170.
Example message sent from England to Germany and France:
> PRP(PTC 1 (ENG GER FRA))

This message asks Germany and France to start using protocol 1 with Germany, France, and England.

The grammar, keyword, visitor, and tests are implemented in this pull request.

**Additional context**
It is intended to allow powers to agree to use protocols with specific requirements or changed interpretations of DAIDE while cleanly falling back to regular DAIDE if the protocol is not supported.

A power indicates that it understands and will participate in this protocol by replying YES (within some timeout).
> YES(PRP(PTC 1 (ENG GER FRA)))

Any other response (REJ, HUH, ignoring the message, etc) is assumed to indicate that this power will not participate in the protocol.

Most of this explanation is copied from https://github.com/SHADE-AI/daidepp/blob/feat/protocol-token/daide-specification.md
in this branch.

I think this token would make it easier for teams to detect at runtime whether other powers support a protocol and fall back to regular DAIDE if necessary.
**Strange Test Issue**
Some visitor tests for tokens I did not change failed because their return values are being wrapped in lists. Removing the visitor test for my new token somehow fixed this error. I think this PR is now ready to merge.