### PR TITLE
Make grammar creation deterministic

### DIFF
--- a/src/daidepp/grammar/grammar_utils.py
+++ b/src/daidepp/grammar/grammar_utils.py
@@ -208,15 +208,6 @@ def _merge_grammars(old_grammar: GrammarDict, new_grammar: GrammarDict) -> Gramm
     return merged_grammar
 
 
-def _merge_shared_key_values(
-    old_grammar: GrammarDict, new_grammar: GrammarDict, shared_keys: Set[str]
-) -> GrammarDict:
-    merged_grammar = {}
-    for key in shared_keys:
-        merged_grammar[key] = _merge_shared_key_value(old_grammar, new_grammar, key)
-    return merged_grammar
-
-
 def _merge_shared_key_value(
     old_grammar: GrammarDict, new_grammar: GrammarDict, shared_key: str
 ) -> str:

--- a/src/daidepp/grammar/grammar_utils.py
+++ b/src/daidepp/grammar/grammar_utils.py
@@ -189,9 +189,11 @@ def _merge_grammars(old_grammar: GrammarDict, new_grammar: GrammarDict) -> Gramm
     old_keys = set(old_grammar.keys())
     new_keys = set(new_grammar.keys())
 
-    old_unique = old_keys.difference(new_keys)
-    new_unique = new_keys.difference(old_keys)
-    shared_keys = new_keys.intersection(old_keys)
+    # Sorting is needed to maintain the original order of the `GrammarDict`s
+    sort_key = (list(old_grammar) + list(new_grammar)).index
+    old_unique = sorted(old_keys.difference(new_keys), key=sort_key)
+    new_unique = sorted(new_keys.difference(old_keys), key=sort_key)
+    shared_keys = sorted(new_keys.intersection(old_keys), key=sort_key)
 
     merged_grammar: GrammarDict = {}
     for key in old_unique:

--- a/src/daidepp/grammar/grammar_utils.py
+++ b/src/daidepp/grammar/grammar_utils.py
@@ -67,7 +67,10 @@ def create_daide_grammar(
     Returns:
         DAIDEGrammar: Grammar object
     """
-    grammar_str = _create_daide_grammar_str(level, allow_just_arrangement, string_type)
+    if allow_just_arrangement and string_type == "message":
+        string_type = "arrangement"
+
+    grammar_str = _create_daide_grammar_str(level, string_type)
     grammar = DAIDEGrammar(grammar_str)
     return grammar
 
@@ -100,7 +103,6 @@ def _create_daide_grammar_dict(
 
 def _create_daide_grammar_str(
     level: Union[DAIDELevel, List[DAIDELevel]] = 30,
-    allow_just_arrangement: bool = False,
     string_type: Literal["message", "arrangement", "all"] = "message",
 ) -> str:
     """Create string representing DAIDE grammar in PEG
@@ -109,10 +111,6 @@ def _create_daide_grammar_str(
         level (Union[DAIDELevel,List[DAIDELevel]], optional):
             The level of DAIDE to make grammar for. Defaults to 30. If its a list,
             only include levels in list rather than all levels up to given value.
-        allow_just_arrangement (bool, optional):
-            if set to True, the parser accepts strings that are only arrangements,
-            in addition to press messages. So, for example, the parser could parse
-            'PCE (GER ITA)'. Normally, this would raise a ParseError. Left for backwards compatibility.
         string_type (Literal["message", "arrangement", "all"], optional):
             if 'message' is passed (default), the grammar will only recognize full DAIDE messages.
             If 'arrangement' is passed, it will recognize messages and arrangements. And if 'all' is
@@ -123,7 +121,7 @@ def _create_daide_grammar_str(
     """
     grammar_dict = _create_daide_grammar_dict(level)
     grammar_str = _create_grammar_str_from_dict(
-        grammar_dict, allow_just_arrangement, string_type
+        grammar_dict, string_type
     )
     return grammar_str
 
@@ -162,7 +160,6 @@ def _sort_grammar_keys(keys: List[str]) -> List[str]:
 
 def _create_grammar_str_from_dict(
     grammar: GrammarDict,
-    allow_just_arrangement: bool = False,
     string_type: Literal["message", "arrangement", "all"] = "message",
 ) -> str:
     grammar_str = ""
@@ -179,9 +176,7 @@ def _create_grammar_str_from_dict(
         if item[0] == "message" and string_type == "message":
             left = item[0]
             right = item[1]
-            if (
-                allow_just_arrangement or string_type == "arrangement"
-            ) and string_type != "all":
+            if string_type == "arrangement":
                 right += " / arrangement"
             grammar_str = f"{left} = {right}\n" + grammar_str
 
@@ -247,9 +242,11 @@ def create_grammar_from_press_keywords(
     DAIDEGrammar
         DAIDEGrammar composed from the list of keywords.
     """
+    if allow_just_arrangement and string_type == "message":
+        string_type = "arrangement"
+
     full_grammar = create_daide_grammar(
         level=DAIDELevel.__args__[-1],
-        allow_just_arrangement=allow_just_arrangement,
         string_type=string_type,
     )
     current_set = set(LEVEL_0.keys())
@@ -331,7 +328,7 @@ def create_grammar_from_press_keywords(
         new_grammar_dict.move_to_end("message", last=False)
 
     new_grammar_str = _create_grammar_str_from_dict(
-        new_grammar_dict, allow_just_arrangement, string_type
+        new_grammar_dict, string_type
     )
     new_grammar = DAIDEGrammar(new_grammar_str)
     return new_grammar

--- a/src/daidepp/grammar/grammar_utils.py
+++ b/src/daidepp/grammar/grammar_utils.py
@@ -128,7 +128,7 @@ def _create_daide_grammar_str(
     return grammar_str
 
 
-def _sort_grammar_keys(keys: List[str]) -> Tuple:
+def _sort_grammar_keys(keys: List[str]) -> List[str]:
     keys_list = []
 
     keys.remove("lpar")

--- a/src/daidepp/grammar/grammar_utils.py
+++ b/src/daidepp/grammar/grammar_utils.py
@@ -173,7 +173,7 @@ def _create_grammar_str_from_dict(
         # message needs to be the first rule in the string, per parsimonious rules:
         # "The first rule is taken to be the default start symbol, but you can override that."
         # https://github.com/erikrose/parsimonious#example-usage
-        if item[0] == "message" and string_type == "message":
+        if item[0] == "message" and string_type in {"message", "arrangement"}:
             left = item[0]
             right = item[1]
             if string_type == "arrangement":


### PR DESCRIPTION
I was encountering a bug in our agent where the same input DAIDE was being parsed properly by `daidepp` in some cases but not in others. I assumed it was the fault of the agent, but I ended up creating a minimal reproduction using only `daidep`:

```python
from daidepp import PRP, create_daide_grammar, daide_visitor

ALL_GRAMMAR = create_daide_grammar(level=160, string_type="all", test=True)
msg = "PRP(XDO((ENG AMY LVP) MTO WAL))"
parse_tree = ALL_GRAMMAR.parse(msg)
parsed_msg = daide_visitor.visit(parse_tree)
print(f"parsed_msg = {parsed_msg!r}")
print(f"type(parsed_msg) = {type(parsed_msg)}")
assert isinstance(parsed_msg, PRP)
```

The string `PRP(XDO((ENG AMY LVP) MTO WAL))` should always be parsed to an object of type `PRP`, but it was often being parsed to a `list` instead. Running the above script repeatedly will show the output can differ.

I ended up figuring out that `daidepp` was generating grammars non-deterministically across runs. Sometimes the grammar ended up leading to a different, incorrect parse, and I was able to even show that (with a low probability) parsing can fail entirely. I have modified this library to generate the grammar deterministically. I also fixed a related bug that prevented proper parsing of arrangements and made some smaller code changes to improve some problems I found during my work.

## Notes

To repeatedly run the above Python script, I used the following Bash script:

```bash
#!/usr/bin/env bash

for ((i = 0; i < 10; i++)); do
  python daide_test.py
done
```

To view the grammar being generated, I used the following patch:

```diff
diff --git a/src/daidepp/grammar/grammar_utils.py b/src/daidepp/grammar/grammar_utils.py
index d2b8c5e..cc69d97 100644
--- a/src/daidepp/grammar/grammar_utils.py
+++ b/src/daidepp/grammar/grammar_utils.py
@@ -45,6 +45,7 @@ def create_daide_grammar(
     level: Union[DAIDELevel, List[DAIDELevel]] = 30,
     allow_just_arrangement: bool = False,
     string_type: Literal["message", "arrangement", "all"] = "message",
+    test: bool = False,
 ) -> DAIDEGrammar:
     """Create a DAIDEGrammar object given a level of DAIDE.

@@ -71,6 +72,10 @@ def create_daide_grammar(
         string_type = "arrangement"

     grammar_str = _create_daide_grammar_str(level, string_type)
+    if test:
+        from pathlib import Path
+        from time import time_ns
+        Path("grammars", f"{string_type}_{level}_{time_ns()}.txt").write_text(grammar_str)
     grammar = DAIDEGrammar(grammar_str)
     return grammar

```

It assumes that a directory named `grammars` already exists. This specific diff used 6c10f7048c5241782ab13ecb775bd0d459882576 as its base.