### PR TITLE
Ensure equal constructed and parsed keyword objects

### DIFF
--- a/src/daidepp/keywords/base_keywords.py
+++ b/src/daidepp/keywords/base_keywords.py
@@ -72,6 +72,11 @@ class MTO(_DAIDEObject):
     unit: Unit
     location: Location
 
+    def __post_init__(self):
+        if isinstance(self.location, str):
+            object.__setattr__(self, "location", Location(province=self.location))
+        super().__post_init__()
+
     def __str__(self):
         return f"( {self.unit} ) MTO {self.location}"
 
@@ -157,6 +162,8 @@ class MoveByCVY(_DAIDEObject):
         self.__post_init__()
 
     def __post_init__(self):
+        if isinstance(self.province, str):
+            object.__setattr__(self, "province", Location(province=self.province))
         super().__post_init__()
         if not self.province_seas:
             raise ValueError(
@@ -179,6 +186,11 @@ class MoveByCVY(_DAIDEObject):
 class RTO(_DAIDEObject):
     unit: Unit
     location: Location
+
+    def __post_init__(self):
+        if isinstance(self.location, str):
+            object.__setattr__(self, "location", Location(province=self.location))
+        super().__post_init__()
 
     def __str__(self):
         return f"( {self.unit} ) RTO {self.location}"

--- a/src/daidepp/keywords/base_keywords.py
+++ b/src/daidepp/keywords/base_keywords.py
@@ -82,6 +82,13 @@ class SUP(_DAIDEObject):
     supported_unit: Unit
     province_no_coast: Optional[ProvinceNoCoast] = None
 
+    def __post_init__(self):
+        if isinstance(self.province_no_coast, Location):
+            object.__setattr__(
+                self, "province_no_coast", self.province_no_coast.province
+            )
+        super().__post_init__()
+
     @property
     def unit(self) -> Unit:
         """Unit attribute to keep API consistent

--- a/src/daidepp/visitor.py
+++ b/src/daidepp/visitor.py
@@ -368,7 +368,7 @@ class DAIDEVisitor(NodeVisitor):
             return SUP(supporting_unit, supported_unit)
         else:
             _, _, province_no_coast = ws_mto_prov = ws_province_no_coast[0]
-            return SUP(supporting_unit, supported_unit, province_no_coast)
+            return SUP(supporting_unit, supported_unit, province_no_coast.province)
 
     def visit_cvy(self, node, visited_children) -> CVY:
         _, convoying_unit, _, _, _, convoyed_unit, _, _, _, province = visited_children

--- a/src/daidepp/visitor.py
+++ b/src/daidepp/visitor.py
@@ -65,7 +65,7 @@ class DAIDEVisitor(NodeVisitor):
         return WHT(unit)
 
     def visit_how(self, node, visited_children) -> HOW:
-        _, _, province_power, _ = visited_children
+        _, _, province_power, _ = visited_children[0]
         return HOW(province_power)
 
     def visit_exp(self, node, visited_children) -> EXP:
@@ -139,7 +139,7 @@ class DAIDEVisitor(NodeVisitor):
 
     def visit_why(self, node, visited_children) -> WHY:
         _, _, why_param, _ = visited_children
-        return WHY(why_param)
+        return WHY(why_param[0])
 
     def visit_pob(self, node, visited_children) -> POB:
         _, _, why, _ = visited_children
@@ -287,7 +287,7 @@ class DAIDEVisitor(NodeVisitor):
             _, start_turn, _, _, end_turn, _ = turn
             return FOR(start_turn, end_turn, arrangement)
         else:
-            return FOR(start_turn, None, arrangement)
+            return FOR(turn, None, arrangement)
 
     def visit_xoy(self, node, visited_children) -> XOY:
         _, _, power_x, _, _, power_y, _ = visited_children
@@ -317,11 +317,11 @@ class DAIDEVisitor(NodeVisitor):
             _,
         ) = visited_children
 
-        recv_power = [recv_power]
+        recv_powers = [recv_power]
         for ws_recv_power in ws_recv_powers:
             _, recv_power = ws_recv_power
-            recv_power.append(recv_power)
-        return SND(power, recv_power, message)
+            recv_powers.append(recv_power)
+        return SND(power, recv_powers, message)
 
     def visit_fwd(self, node, visited_children) -> FWD:
         _, _, power, ws_powers, _, _, power_1, _, _, power_2, _ = visited_children

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,31 @@ from typing_extensions import get_args
 
 from daidepp.grammar import create_daide_grammar
 from daidepp.grammar.grammar import DAIDELevel
+from daidepp.keywords.press_keywords import AnyDAIDEToken
+from daidepp.visitor import daide_visitor
+
+# Declared outside of fixture for performance
+MAX_DAIDE_LEVEL = get_args(DAIDELevel)[-1]
+ALL_GRAMMAR = create_daide_grammar(level=MAX_DAIDE_LEVEL, string_type="all")
+
+
+@pytest.fixture
+def daide_parser():
+    """Helper function to ensure grammar and visitor construct correct DAIDE objects"""
+
+    def parse_daide(string: str) -> AnyDAIDEToken:
+        """Parses a DAIDE string into `daidepp` objects.
+        :param string: String to parse into DAIDE.
+        :return: Parsed DAIDE object.
+        :raises ValueError: If string is invalid DAIDE.
+        """
+        try:
+            parse_tree = ALL_GRAMMAR.parse(string)
+            return daide_visitor.visit(parse_tree)
+        except Exception as ex:
+            raise ValueError(f"Failed to parse DAIDE string: {string!r}") from ex
+
+    return parse_daide
 
 
 @pytest.fixture(scope="session")

--- a/tests/keywords/test_base_keywords.py
+++ b/tests/keywords/test_base_keywords.py
@@ -16,7 +16,6 @@ from daidepp.keywords.base_keywords import *
     ],
 )
 def test_Unit(input, expected_output):
-    print(input)
     unit = Unit(*input)
     assert str(unit) == expected_output
     hash(unit)

--- a/tests/keywords/test_base_keywords.py
+++ b/tests/keywords/test_base_keywords.py
@@ -19,6 +19,7 @@ def test_Unit(input, expected_output):
     print(input)
     unit = Unit(*input)
     assert str(unit) == expected_output
+    hash(unit)
 
 
 @pytest.mark.parametrize(
@@ -31,6 +32,7 @@ def test_Unit(input, expected_output):
 def test_HLD(input, expected_output):
     hld = HLD(*input)
     assert str(hld) == expected_output
+    hash(hld)
 
 
 @pytest.mark.parametrize(
@@ -43,6 +45,7 @@ def test_HLD(input, expected_output):
 def test_MTO(input, expected_output):
     mto = MTO(*input)
     assert str(mto) == expected_output
+    hash(mto)
 
 
 @pytest.mark.parametrize(
@@ -77,6 +80,7 @@ def test_MTO(input, expected_output):
 def test_SUP(input, expected_output):
     sup = SUP(*input)
     assert str(sup) == expected_output
+    hash(sup)
 
 
 @pytest.mark.parametrize(
@@ -102,6 +106,7 @@ def test_SUP_location(supporting_unit, supported_unit, province_no_coast):
     )
     assert isinstance(sup.province_no_coast, str)
     assert isinstance(sup.province_no_coast_location, Location)
+    hash(sup)
 
 
 @pytest.mark.parametrize(
@@ -120,6 +125,7 @@ def test_SUP_location(supporting_unit, supported_unit, province_no_coast):
 def test_CVY(input, expected_output):
     cvy = CVY(*input)
     assert str(cvy) == expected_output
+    hash(cvy)
 
 
 @pytest.mark.parametrize(
@@ -142,6 +148,7 @@ def test_CVY(input, expected_output):
 def test_MoveByCVY(input, expected_output):
     mvc = MoveByCVY(*input)
     assert str(mvc) == expected_output
+    hash(mvc)
 
 
 @pytest.mark.parametrize(
@@ -154,6 +161,7 @@ def test_MoveByCVY(input, expected_output):
 def test_RTO(input, expected_output):
     rto = RTO(*input)
     assert str(rto) == expected_output
+    hash(rto)
 
 
 @pytest.mark.parametrize(
@@ -166,6 +174,7 @@ def test_RTO(input, expected_output):
 def test_DSB(input, expected_output):
     dsb = DSB(*input)
     assert str(dsb) == expected_output
+    hash(dsb)
 
 
 @pytest.mark.parametrize(
@@ -178,6 +187,7 @@ def test_DSB(input, expected_output):
 def test_BLD(input, expected_output):
     bld = BLD(*input)
     assert str(bld) == expected_output
+    hash(bld)
 
 
 @pytest.mark.parametrize(
@@ -190,6 +200,7 @@ def test_BLD(input, expected_output):
 def test_REM(input, expected_output):
     rem = REM(*input)
     assert str(rem) == expected_output
+    hash(rem)
 
 
 @pytest.mark.parametrize(
@@ -202,6 +213,7 @@ def test_REM(input, expected_output):
 def test_WVE(input, expected_output):
     wve = WVE(*input)
     assert str(wve) == expected_output
+    hash(wve)
 
 
 @pytest.mark.parametrize(
@@ -213,3 +225,4 @@ def test_WVE(input, expected_output):
 def test_turn(input, expected_output):
     turn_1 = Turn(*input)
     assert str(turn_1) == expected_output
+    hash(turn_1)

--- a/tests/keywords/test_base_keywords.py
+++ b/tests/keywords/test_base_keywords.py
@@ -15,9 +15,10 @@ from daidepp.keywords.base_keywords import *
         (("TUR", "FLT", "BRE"), "TUR FLT BRE"),
     ],
 )
-def test_Unit(input, expected_output):
+def test_Unit(input, expected_output, daide_parser):
     unit = Unit(*input)
     assert str(unit) == expected_output
+    assert unit == daide_parser(expected_output)
     hash(unit)
 
 
@@ -28,9 +29,10 @@ def test_Unit(input, expected_output):
         ((Unit("ENG", "AMY", "ANK"),), "( ENG AMY ANK ) HLD"),
     ],
 )
-def test_HLD(input, expected_output):
+def test_HLD(input, expected_output, daide_parser):
     hld = HLD(*input)
     assert str(hld) == expected_output
+    assert hld == daide_parser(expected_output)
     hash(hld)
 
 
@@ -38,12 +40,15 @@ def test_HLD(input, expected_output):
     ["input", "expected_output"],
     [
         ((Unit("AUS", "FLT", "ALB"), "BUL"), "( AUS FLT ALB ) MTO BUL"),
+        ((Unit("AUS", "FLT", "ALB"), Location("BUL")), "( AUS FLT ALB ) MTO BUL"),
         ((Unit("ENG", "AMY", "ANK"), "CLY"), "( ENG AMY ANK ) MTO CLY"),
+        ((Unit("ENG", "AMY", "ANK"), Location("CLY")), "( ENG AMY ANK ) MTO CLY"),
     ],
 )
-def test_MTO(input, expected_output):
+def test_MTO(input, expected_output, daide_parser):
     mto = MTO(*input)
     assert str(mto) == expected_output
+    assert mto == daide_parser(expected_output)
     hash(mto)
 
 
@@ -76,9 +81,10 @@ def test_MTO(input, expected_output):
         ),
     ],
 )
-def test_SUP(input, expected_output):
+def test_SUP(input, expected_output, daide_parser):
     sup = SUP(*input)
     assert str(sup) == expected_output
+    assert sup == daide_parser(expected_output)
     hash(sup)
 
 
@@ -97,7 +103,7 @@ def test_SUP(input, expected_output):
         ),
     ],
 )
-def test_SUP_location(supporting_unit, supported_unit, province_no_coast):
+def test_SUP_location(supporting_unit, supported_unit, province_no_coast, daide_parser):
     sup = SUP(
         supported_unit=supported_unit,
         supporting_unit=supporting_unit,
@@ -105,6 +111,7 @@ def test_SUP_location(supporting_unit, supported_unit, province_no_coast):
     )
     assert isinstance(sup.province_no_coast, str)
     assert isinstance(sup.province_no_coast_location, Location)
+    assert sup == daide_parser(str(sup))
     hash(sup)
 
 
@@ -121,9 +128,10 @@ def test_SUP_location(supporting_unit, supported_unit, province_no_coast):
         ),
     ],
 )
-def test_CVY(input, expected_output):
+def test_CVY(input, expected_output, daide_parser):
     cvy = CVY(*input)
     assert str(cvy) == expected_output
+    assert cvy == daide_parser(expected_output)
     hash(cvy)
 
 
@@ -142,11 +150,24 @@ def test_CVY(input, expected_output):
             (Unit("FRA", "FLT", "APU"), "CON", "ADR", "AEG", "BAL"),
             "( FRA FLT APU ) CTO CON VIA ( ADR AEG BAL )",
         ),
+        (
+            (Unit("AUS", "FLT", "ALB"), Location("BUL"), "ADR"),
+            "( AUS FLT ALB ) CTO BUL VIA ( ADR )",
+        ),
+        (
+            (Unit("ENG", "AMY", "ANK"), Location("CLY"), "ADR", "AEG"),
+            "( ENG AMY ANK ) CTO CLY VIA ( ADR AEG )",
+        ),
+        (
+            (Unit("FRA", "FLT", "APU"), Location("CON"), "ADR", "AEG", "BAL"),
+            "( FRA FLT APU ) CTO CON VIA ( ADR AEG BAL )",
+        ),
     ],
 )
-def test_MoveByCVY(input, expected_output):
+def test_MoveByCVY(input, expected_output, daide_parser):
     mvc = MoveByCVY(*input)
     assert str(mvc) == expected_output
+    assert mvc == daide_parser(expected_output)
     hash(mvc)
 
 
@@ -154,12 +175,15 @@ def test_MoveByCVY(input, expected_output):
     ["input", "expected_output"],
     [
         ((Unit("AUS", "FLT", "ALB"), "BUL"), "( AUS FLT ALB ) RTO BUL"),
+        ((Unit("AUS", "FLT", "ALB"), Location("BUL")), "( AUS FLT ALB ) RTO BUL"),
         ((Unit("ENG", "AMY", "ANK"), "CLY"), "( ENG AMY ANK ) RTO CLY"),
+        ((Unit("ENG", "AMY", "ANK"), Location("CLY")), "( ENG AMY ANK ) RTO CLY"),
     ],
 )
-def test_RTO(input, expected_output):
+def test_RTO(input, expected_output, daide_parser):
     rto = RTO(*input)
     assert str(rto) == expected_output
+    assert rto == daide_parser(expected_output)
     hash(rto)
 
 
@@ -170,9 +194,10 @@ def test_RTO(input, expected_output):
         ((Unit("ENG", "AMY", "ANK"),), "( ENG AMY ANK ) DSB"),
     ],
 )
-def test_DSB(input, expected_output):
+def test_DSB(input, expected_output, daide_parser):
     dsb = DSB(*input)
     assert str(dsb) == expected_output
+    assert dsb == daide_parser(expected_output)
     hash(dsb)
 
 
@@ -183,9 +208,10 @@ def test_DSB(input, expected_output):
         ((Unit("ENG", "AMY", "ANK"),), "( ENG AMY ANK ) BLD"),
     ],
 )
-def test_BLD(input, expected_output):
+def test_BLD(input, expected_output, daide_parser):
     bld = BLD(*input)
     assert str(bld) == expected_output
+    assert bld == daide_parser(expected_output)
     hash(bld)
 
 
@@ -196,9 +222,10 @@ def test_BLD(input, expected_output):
         ((Unit("ENG", "AMY", "ANK"),), "( ENG AMY ANK ) REM"),
     ],
 )
-def test_REM(input, expected_output):
+def test_REM(input, expected_output, daide_parser):
     rem = REM(*input)
     assert str(rem) == expected_output
+    assert rem == daide_parser(expected_output)
     hash(rem)
 
 
@@ -209,9 +236,10 @@ def test_REM(input, expected_output):
         (("ENG",), "ENG WVE"),
     ],
 )
-def test_WVE(input, expected_output):
+def test_WVE(input, expected_output, daide_parser):
     wve = WVE(*input)
     assert str(wve) == expected_output
+    assert wve == daide_parser(expected_output)
     hash(wve)
 
 
@@ -221,7 +249,8 @@ def test_WVE(input, expected_output):
         (("SPR", 1901), "SPR 1901"),
     ],
 )
-def test_turn(input, expected_output):
+def test_turn(input, expected_output, daide_parser):
     turn_1 = Turn(*input)
     assert str(turn_1) == expected_output
+    assert turn_1 == daide_parser(expected_output)
     hash(turn_1)

--- a/tests/keywords/test_base_keywords.py
+++ b/tests/keywords/test_base_keywords.py
@@ -100,6 +100,7 @@ def test_SUP_location(supporting_unit, supported_unit, province_no_coast):
         supporting_unit=supporting_unit,
         province_no_coast=province_no_coast,
     )
+    assert isinstance(sup.province_no_coast, str)
     assert isinstance(sup.province_no_coast_location, Location)
 
 

--- a/tests/keywords/test_press_keywords.py
+++ b/tests/keywords/test_press_keywords.py
@@ -16,9 +16,6 @@ from daidepp.keywords.press_keywords import *
 def test_PCE(input, expected_output):
     pce = PCE(*input)
     assert str(pce) == expected_output
-
-    with pytest.raises(Exception):
-        PCE("AUS")
     hash(pce)
 
 

--- a/tests/keywords/test_press_keywords.py
+++ b/tests/keywords/test_press_keywords.py
@@ -434,7 +434,7 @@ def test_OCC(input, expected_substrings):
     hash(occ)
 
     reversed_input = reversed(input)
-    occ_2 = OCC(*input)
+    occ_2 = OCC(*reversed_input)
     assert occ == occ_2
 
 

--- a/tests/keywords/test_press_keywords.py
+++ b/tests/keywords/test_press_keywords.py
@@ -13,9 +13,10 @@ from daidepp.keywords.press_keywords import *
         (("AUS", "ENG", "FRA"), "PCE ( AUS ENG FRA )"),
     ],
 )
-def test_PCE(input, expected_output):
+def test_PCE(input, expected_output, daide_parser):
     pce = PCE(*input)
     assert str(pce) == expected_output
+    assert pce == daide_parser(expected_output)
     hash(pce)
 
 
@@ -37,9 +38,10 @@ def test_PCE_bad(input):
         ((PCE("AUS", "ENG", "FRA"),), "PRP ( PCE ( AUS ENG FRA ) )"),
     ],
 )
-def test_PRP(input, expected_output):
+def test_PRP(input, expected_output, daide_parser):
     arr = PRP(*input)
     assert str(arr) == expected_output
+    assert arr == daide_parser(expected_output)
     hash(arr)
 
 
@@ -55,9 +57,10 @@ def test_PRP_bad():
         ((PRP(PCE("AUS", "ENG", "FRA")),), "CCL ( PRP ( PCE ( AUS ENG FRA ) ) )"),
     ],
 )
-def test_CCL(input, expected_output):
+def test_CCL(input, expected_output, daide_parser):
     ccl = CCL(*input)
     assert str(ccl) == expected_output
+    assert ccl == daide_parser(expected_output)
     hash(ccl)
 
 
@@ -82,9 +85,10 @@ def test_CCL(input, expected_output):
         ),
     ],
 )
-def test_TRY(input, expected_output):
+def test_TRY(input, expected_output, daide_parser):
     try_1 = TRY(*input)
     assert str(try_1) == expected_output
+    assert try_1 == daide_parser(expected_output)
     hash(try_1)
 
     reversed_input = reversed(input)
@@ -99,9 +103,10 @@ def test_TRY(input, expected_output):
         ((PRP(PCE("AUS", "ENG", "FRA")),), "HUH ( PRP ( PCE ( AUS ENG FRA ) ) )"),
     ],
 )
-def test_HUH(input, expected_output):
+def test_HUH(input, expected_output, daide_parser):
     huh_1 = HUH(*input)
     assert str(huh_1) == expected_output
+    assert huh_1 == daide_parser(expected_output)
     hash(huh_1)
 
 
@@ -117,9 +122,10 @@ def test_HUH(input, expected_output):
         ),
     ],
 )
-def test_ALYVSS(input, expected_output):
+def test_ALYVSS(input, expected_output, daide_parser):
     alyvss = ALYVSS(*input)
     assert str(alyvss) == expected_output
+    assert alyvss == daide_parser(expected_output)
     hash(alyvss)
 
 
@@ -153,9 +159,10 @@ def test_ALYVSS_bad(input):
         (("GER",), "SLO ( GER )"),
     ],
 )
-def test_SLO(input, expected_output):
+def test_SLO(input, expected_output, daide_parser):
     slo = SLO(*input)
     assert str(slo) == expected_output
+    assert slo == daide_parser(expected_output)
     hash(slo)
 
 
@@ -165,9 +172,10 @@ def test_SLO(input, expected_output):
         ((PCE("AUS", "ENG"),), "NOT ( PCE ( AUS ENG ) )"),
     ],
 )
-def test_NOT(input, expected_output):
+def test_NOT(input, expected_output, daide_parser):
     not_1 = NOT(*input)
     assert str(not_1) == expected_output
+    assert not_1 == daide_parser(expected_output)
     hash(not_1)
 
 
@@ -177,9 +185,10 @@ def test_NOT(input, expected_output):
         ((PCE("AUS", "ENG"),), "NAR ( PCE ( AUS ENG ) )"),
     ],
 )
-def test_NAR(input, expected_output):
+def test_NAR(input, expected_output, daide_parser):
     nar = NAR(*input)
     assert str(nar) == expected_output
+    assert nar == daide_parser(expected_output)
     hash(nar)
 
 
@@ -196,9 +205,10 @@ def test_NAR(input, expected_output):
         ),
     ],
 )
-def test_DRW(input, expected_output):
+def test_DRW(input, expected_output, daide_parser):
     drw = DRW(*input)
     assert str(drw) == expected_output
+    assert drw == daide_parser(expected_output)
     hash(drw)
 
 
@@ -208,9 +218,10 @@ def test_DRW(input, expected_output):
         ((PRP(PCE("AUS", "ENG")),), "YES ( PRP ( PCE ( AUS ENG ) ) )"),
     ],
 )
-def test_YES(input, expected_output):
+def test_YES(input, expected_output, daide_parser):
     yes = YES(*input)
     assert str(yes) == expected_output
+    assert yes == daide_parser(expected_output)
     hash(yes)
 
 
@@ -220,9 +231,10 @@ def test_YES(input, expected_output):
         ((PRP(PCE("AUS", "ENG")),), "REJ ( PRP ( PCE ( AUS ENG ) ) )"),
     ],
 )
-def test_REJ(input, expected_output):
+def test_REJ(input, expected_output, daide_parser):
     rej = REJ(*input)
     assert str(rej) == expected_output
+    assert rej == daide_parser(expected_output)
     hash(rej)
 
 
@@ -232,9 +244,10 @@ def test_REJ(input, expected_output):
         ((PRP(PCE("AUS", "ENG")),), "BWX ( PRP ( PCE ( AUS ENG ) ) )"),
     ],
 )
-def test_BWX(input, expected_output):
+def test_BWX(input, expected_output, daide_parser):
     bwx = BWX(*input)
     assert str(bwx) == expected_output
+    assert bwx == daide_parser(expected_output)
     hash(bwx)
 
 
@@ -245,9 +258,10 @@ def test_BWX(input, expected_output):
         ((NOT(PCE("AUS", "ENG")),), "FCT ( NOT ( PCE ( AUS ENG ) ) )"),
     ],
 )
-def test_FCT(input, expected_output):
+def test_FCT(input, expected_output, daide_parser):
     fct = FCT(*input)
     assert str(fct) == expected_output
+    assert fct == daide_parser(expected_output)
     hash(fct)
 
 
@@ -264,10 +278,11 @@ def test_FCT(input, expected_output):
         ),
     ],
 )
-def test_FRM(input, expected_output):
+def test_FRM(input, expected_output, daide_parser):
     frm = FRM(*input)
 
     assert str(frm) == expected_output
+    assert frm == daide_parser(expected_output)
     hash(frm)
 
 
@@ -281,9 +296,10 @@ def test_FRM(input, expected_output):
         ),
     ],
 )
-def test_XDO(input, expected_output):
+def test_XDO(input, expected_output, daide_parser):
     xdo = XDO(*input)
     assert str(xdo) == expected_output
+    assert xdo == daide_parser(expected_output)
     hash(xdo)
 
 
@@ -306,9 +322,10 @@ def test_XDO(input, expected_output):
         ),
     ],
 )
-def test_DMZ(input, expected_output):
+def test_DMZ(input, expected_output, daide_parser):
     dmz = DMZ(*input)
     assert str(dmz) == expected_output
+    assert dmz == daide_parser(expected_output)
     hash(dmz)
 
     reversed_inputs = map(reversed, input)
@@ -336,8 +353,10 @@ def test_DMZ(input, expected_output):
         ),
     ],
 )
-def test_AND(input, expected_substrings):
+def test_AND(input, expected_substrings, daide_parser):
     and_1 = AND(*input)
+    and_str = str(and_1)
+    assert and_1 == daide_parser(and_str)
     for substring in expected_substrings:
         assert substring in str(and_1)
 
@@ -368,9 +387,10 @@ def test_AND(input, expected_substrings):
         ),
     ],
 )
-def test_ORR(input, expected_substrings):
+def test_ORR(input, expected_substrings, daide_parser):
     orr = ORR(*input)
     orr_str = str(orr)
+    assert orr == daide_parser(orr_str)
     for substring in expected_substrings:
         assert substring in orr_str
 
@@ -398,9 +418,10 @@ def test_ORR(input, expected_substrings):
         ),
     ],
 )
-def test_SCD(input, expected_regex_substrings):
+def test_SCD(input, expected_regex_substrings, daide_parser):
     scd = SCD(*input)
     scd_str = str(scd)
+    assert scd == daide_parser(scd_str)
     for substring in expected_regex_substrings:
         r = re.compile(substring)
         assert re.search(r, scd_str)
@@ -425,9 +446,10 @@ def test_SCD(input, expected_regex_substrings):
         ),
     ],
 )
-def test_OCC(input, expected_substrings):
+def test_OCC(input, expected_substrings, daide_parser):
     occ = OCC(*input)
     occ_str = str(occ)
+    assert occ == daide_parser(occ_str)
     for substring in expected_substrings:
         assert substring in occ_str
 
@@ -444,11 +466,12 @@ def test_OCC(input, expected_substrings):
         [(1901, 1903, PCE("AUS", "GER"), PCE("AUS", "ENG"))],
     ],
 )
-def test_CHO(input):
+def test_CHO(input, daide_parser):
     cho = CHO(*input)
     for arrangement in input[2:]:
         assert arrangement in cho.arrangements
 
+    assert cho == daide_parser(str(cho))
     hash(cho)
 
     arrangements = list(reversed(input[2:]))
@@ -462,9 +485,10 @@ def test_CHO(input):
         ((PCE("AUS", "GER"),), "INS ( PCE ( AUS GER ) )"),
     ],
 )
-def test_INS(input, expected_output):
+def test_INS(input, expected_output, daide_parser):
     ins = INS(*input)
     assert str(ins) == expected_output
+    assert ins == daide_parser(expected_output)
     hash(ins)
 
 
@@ -474,9 +498,10 @@ def test_INS(input, expected_output):
         ((PCE("AUS", "GER"),), "QRY ( PCE ( AUS GER ) )"),
     ],
 )
-def test_QRY(input, expected_output):
+def test_QRY(input, expected_output, daide_parser):
     qry = QRY(*input)
     assert str(qry) == expected_output
+    assert qry == daide_parser(expected_output)
     hash(qry)
 
 
@@ -486,9 +511,10 @@ def test_QRY(input, expected_output):
         ((PCE("AUS", "GER"),), "THK ( PCE ( AUS GER ) )"),
     ],
 )
-def test_THK(input, expected_output):
+def test_THK(input, expected_output, daide_parser):
     thk = THK(*input)
     assert str(thk) == expected_output
+    assert thk == daide_parser(expected_output)
     hash(thk)
 
 
@@ -498,9 +524,10 @@ def test_THK(input, expected_output):
         ((PRP(PCE("AUS", "GER")),), "IDK ( PRP ( PCE ( AUS GER ) ) )"),
     ],
 )
-def test_IDK(input, expected_output):
+def test_IDK(input, expected_output, daide_parser):
     idk = IDK(*input)
     assert str(idk) == expected_output
+    assert idk == daide_parser(expected_output)
     hash(idk)
 
 
@@ -510,9 +537,10 @@ def test_IDK(input, expected_output):
         ((PCE("AUS", "GER"),), "SUG ( PCE ( AUS GER ) )"),
     ],
 )
-def test_SUG(input, expected_output):
+def test_SUG(input, expected_output, daide_parser):
     sug = SUG(*input)
     assert str(sug) == expected_output
+    assert sug == daide_parser(expected_output)
     hash(sug)
 
 
@@ -522,10 +550,11 @@ def test_SUG(input, expected_output):
         ((Unit("AUS", "FLT", Location("ALB")),), "WHT ( AUS FLT ALB )"),
     ],
 )
-def test_WHT(input, expected_output):
+def test_WHT(input, expected_output, daide_parser):
     wht = WHT(*input)
 
     assert str(wht) == expected_output
+    assert wht == daide_parser(expected_output)
     hash(wht)
 
 
@@ -536,9 +565,10 @@ def test_WHT(input, expected_output):
         ((Location("APU"),), "HOW ( APU )"),
     ],
 )
-def test_HOW(input, expected_output):
+def test_HOW(input, expected_output, daide_parser):
     how = HOW(*input)
     assert str(how) == expected_output
+    assert how == daide_parser(expected_output)
     hash(how)
 
 
@@ -554,10 +584,11 @@ def test_HOW(input, expected_output):
         ),
     ],
 )
-def test_EXP(input, expected_output):
+def test_EXP(input, expected_output, daide_parser):
     exp = EXP(*input)
 
     assert str(exp) == expected_output
+    assert exp == daide_parser(expected_output)
     hash(exp)
 
 
@@ -570,10 +601,11 @@ def test_EXP(input, expected_output):
         ),
     ],
 )
-def test_SRY(input, expected_output):
+def test_SRY(input, expected_output, daide_parser):
     sry = SRY(*input)
 
     assert str(sry) == expected_output
+    assert sry == daide_parser(expected_output)
     hash(sry)
 
 
@@ -598,9 +630,10 @@ def test_SRY(input, expected_output):
         ),
     ],
 )
-def test_FOR(input, expected_output):
+def test_FOR(input, expected_output, daide_parser):
     for_1 = FOR(*input)
     assert str(for_1) == expected_output
+    assert for_1 == daide_parser(expected_output)
     hash(for_1)
 
 
@@ -624,9 +657,10 @@ def test_FOR(input, expected_output):
         ),
     ],
 )
-def test_IFF(input, expected_output):
+def test_IFF(input, expected_output, daide_parser):
     iff = IFF(*input)
     assert str(iff) == expected_output
+    assert iff == daide_parser(expected_output)
     hash(iff)
 
 
@@ -642,9 +676,10 @@ def test_IFF(input, expected_output):
         ),
     ],
 )
-def test_XOY(input, expected_output):
+def test_XOY(input, expected_output, daide_parser):
     xoy_1 = XOY(*input)
     assert str(xoy_1) == expected_output
+    assert xoy_1 == daide_parser(expected_output)
     hash(xoy_1)
 
 
@@ -668,9 +703,10 @@ def test_XOY(input, expected_output):
         ),
     ],
 )
-def test_YDO(input, expected_output):
+def test_YDO(input, expected_output, daide_parser):
     ydo = YDO(*input)
     assert str(ydo) == expected_output
+    assert ydo == daide_parser(expected_output)
     hash(ydo)
 
 
@@ -687,9 +723,10 @@ def test_YDO(input, expected_output):
         ),
     ],
 )
-def test_SND(input, expected_output):
+def test_SND(input, expected_output, daide_parser):
     snd = SND(*input)
     assert str(snd) == expected_output
+    assert snd == daide_parser(expected_output)
     hash(snd)
 
 
@@ -706,9 +743,10 @@ def test_SND(input, expected_output):
         ),
     ],
 )
-def test_FWD(input, expected_output):
+def test_FWD(input, expected_output, daide_parser):
     fwd = FWD(*input)
     assert str(fwd) == expected_output
+    assert fwd == daide_parser(expected_output)
     hash(fwd)
 
 
@@ -725,9 +763,10 @@ def test_FWD(input, expected_output):
         ),
     ],
 )
-def test_BCC(input, expected_output):
+def test_BCC(input, expected_output, daide_parser):
     bcc = BCC(*input)
     assert str(bcc) == expected_output
+    assert bcc == daide_parser(expected_output)
     hash(bcc)
 
 
@@ -737,9 +776,10 @@ def test_BCC(input, expected_output):
         ((PRP(PCE("AUS", "GER")),), "WHY ( PRP ( PCE ( AUS GER ) ) )"),
     ],
 )
-def test_WHY(input, expected_output):
+def test_WHY(input, expected_output, daide_parser):
     why = WHY(*input)
     assert str(why) == expected_output
+    assert why == daide_parser(expected_output)
     hash(why)
 
 
@@ -749,9 +789,10 @@ def test_WHY(input, expected_output):
         ((WHY(PRP(PCE("AUS", "GER"))),), "POB ( WHY ( PRP ( PCE ( AUS GER ) ) ) )"),
     ],
 )
-def test_POB(input, expected_output):
+def test_POB(input, expected_output, daide_parser):
     pob = POB(*input)
     assert str(pob) == expected_output
+    assert pob == daide_parser(expected_output)
     hash(pob)
 
 
@@ -761,9 +802,10 @@ def test_POB(input, expected_output):
         ((PRP(PCE("AUS", "GER")),), "UHY ( PRP ( PCE ( AUS GER ) ) )"),
     ],
 )
-def test_UHY(input, expected_output):
+def test_UHY(input, expected_output, daide_parser):
     uhy = UHY(*input)
     assert str(uhy) == expected_output
+    assert uhy == daide_parser(expected_output)
     hash(uhy)
 
 
@@ -773,9 +815,10 @@ def test_UHY(input, expected_output):
         ((PRP(PCE("AUS", "GER")),), "HPY ( PRP ( PCE ( AUS GER ) ) )"),
     ],
 )
-def test_HPY(input, expected_output):
+def test_HPY(input, expected_output, daide_parser):
     hpy = HPY(*input)
     assert str(hpy) == expected_output
+    assert hpy == daide_parser(expected_output)
     hash(hpy)
 
 
@@ -785,15 +828,17 @@ def test_HPY(input, expected_output):
         ((PRP(PCE("AUS", "GER")),), "ANG ( PRP ( PCE ( AUS GER ) ) )"),
     ],
 )
-def test_ANG(input, expected_output):
+def test_ANG(input, expected_output, daide_parser):
     ang = ANG(*input)
     assert str(ang) == expected_output
+    assert ang == daide_parser(expected_output)
     hash(ang)
 
 
-def test_ROF():
+def test_ROF(daide_parser):
     rof = ROF()
     assert str(rof) == "ROF"
+    assert rof == daide_parser("ROF")
     hash(rof)
 
 
@@ -805,9 +850,10 @@ def test_ROF():
         (("AUS", 0.2), "ULB ( AUS 0.2 )"),
     ],
 )
-def test_ULB(input, expected_output):
+def test_ULB(input, expected_output, daide_parser):
     ulb = ULB(*input)
     assert str(ulb) == expected_output
+    assert ulb == daide_parser(expected_output)
     hash(ulb)
 
 
@@ -819,7 +865,8 @@ def test_ULB(input, expected_output):
         (("AUS", 0.2), "UUB ( AUS 0.2 )"),
     ],
 )
-def test_UUB(input, expected_output):
+def test_UUB(input, expected_output, daide_parser):
     uub = UUB(*input)
     assert str(uub) == expected_output
+    assert uub == daide_parser(expected_output)
     hash(uub)


### PR DESCRIPTION
I while working on the ALLAN bot, I encountered a bug where `SUP.province_no_coast` was being parsed to the wrong type. I fixed it, but I figured I should check for similar cases. It turns out that although we had full coverage of the form `assert str(daide_obj) == daide_str`, we had no checks for the form `assert daide_object == parse_daide(daide_str)`. I have added these checks, fixed the cases where they did not passed, and made some small changes for other problems I noticed during the process.