### PR TITLE
Make keyword-based grammar creation deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,25 @@ Example:
 ```python3
 >>> from daidepp import create_daide_grammar, daide_visitor
 >>> grammar = create_daide_grammar(level=130)
->>> message = 'PRP (AND (AND (SLO (ENG)) (SLO (GER)) (SLO (RUS))) (AND (SLO (ENG)) (SLO (GER)) (SLO (RUS))))'
+>>> message = 'PRP (AND (SLO (ENG)) (SLO (GER)) (SLO (RUS)))'
 >>> parse_tree = grammar.parse(message)
 >>> output = daide_visitor.visit(parse_tree) # object composed of dataclass objects in keywords.py
->>> print(output)
-`PRP ( AND ( AND ( SLO ( ENG ) ) ( SLO ( GER ) ) ( SLO ( RUS ) ) ) ( AND ( SLO ( ENG ) ) ( SLO ( GER ) ) ( SLO ( RUS ) ) ) )`
+>>> str(output)
+'PRP ( AND ( SLO ( ENG ) ) ( SLO ( GER ) ) ( SLO ( RUS ) ) )'
 ```
 
 The daide_visitor outputs a dataclass that can be used to access useful information about the message.
 ```python3
->>> grammar = create_daide_grammar(level=130, allow_just_arrangement=True) # allows for messages without PRP
+>>> from daidepp import create_daide_grammar, daide_visitor
+>>> grammar = create_daide_grammar(level=130, string_type="arrangement") # allows for messages without PRP
 >>> parse_tree = grammar.parse('ALY (GER FRA) VSS (TUR ITA)')
 >>> output = daide_visitor.visit(parse_tree)
->>> print(output)
-`ALY ( GER FRA ) VSS ( TUR ITA )`
->>> print(output.aly_power)
-['GER', 'FRA']
->>> print(output.vss_power)
-['TUR','ITA']
+>>> str(output)
+'ALY ( FRA GER ) VSS ( ITA TUR )'
+>>> output.aly_powers
+('FRA', 'GER')
+>>> output.vss_powers
+('ITA', 'TUR')
 ```
 
 If the DAIDE token is not in the grammar or if the message is malformed, the parser will just throw an exception. We're currently working on returning a list of unrecognized tokens instead of just erroring out.
@@ -51,9 +52,9 @@ In addition, DAIDE strings can be constructed using the classes in [`base_keywor
 Example:
 
 ```python3
->>> from daidepp import AND, PRP, PCE
+>>> from daidepp import AND, PCE
 >>> str(AND(PCE("AUS", "ENG"), PCE("AUS", "ENG"), PCE("AUS", "ENG", "FRA")))
-`AND ( PCE ( AUS ENG ) ) ( PCE ( AUS ENG ) ) ( PCE ( AUS ENG FRA ) )`
+'AND ( PCE ( AUS ENG ) ) ( PCE ( AUS ENG FRA ) )'
 ```
 Each keyword class uses different parameters for instantiation, so it is recommended to carefully follow the type hints or checkout [`tests/keywords`](./tests/keywords/), which provides examples for each class. 
 
@@ -63,7 +64,7 @@ Grammar can also be created using a subset of press keywords. The list of press 
 Example:
 ```python3
 >>> from daidepp.grammar.grammar_utils import create_grammar_from_press_keywords
->>> grammar = create_grammar_from_press_keywords(["PRP", "XDO", "ALY_VSS"]
+>>> grammar = create_grammar_from_press_keywords(["PRP", "XDO", "ALY_VSS"])
 >>> grammar.parse("PRP (ALY (ITA TUR) VSS (ENG RUS))")
 >>> grammar.parse("PRP(XDO((ENG FLT EDI) SUP (ENG AMY LVP) MTO CLY))")
 >>> grammar.parse("PRP(PCE (AUS ENG))") # this would fail

--- a/src/daidepp/grammar/grammar.py
+++ b/src/daidepp/grammar/grammar.py
@@ -5,12 +5,14 @@ For now this grammar assumes NO PDA games
 from __future__ import annotations
 
 from typing import Dict, Tuple
+from typing_extensions import get_args
 
 from typing_extensions import Literal
 
 DAIDELevel = Literal[
     0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160
 ]
+MAX_DAIDE_LEVEL = get_args(DAIDELevel)[-1]
 
 TRAIL_TOKEN = "---"  # any value starting with '---' is meant to be a continuation of that key, not a replacement
 

--- a/src/daidepp/grammar/grammar_utils.py
+++ b/src/daidepp/grammar/grammar_utils.py
@@ -272,7 +272,7 @@ def create_grammar_from_press_keywords(
         member.literal.lower() for member in full_grammar["try_tokens"].members
     ]
     keyword_dependencies_special_keywords = defaultdict(list)
-    for keyword in current_set:
+    for keyword in sorted(current_set):
         # 'message' is only added if press_message or reply is added
         for special_keyword in [
             "arrangement",

--- a/src/daidepp/grammar/grammar_utils.py
+++ b/src/daidepp/grammar/grammar_utils.py
@@ -226,8 +226,7 @@ def create_grammar_from_press_keywords(
     Parameters
     ----------
     keywords : List[PressKeywords]
-        List of press keywords. Although the type hint says List[PressKeywords],
-        this can be a list of string literals or DAIDEObjects (to avoid circular imports).
+        List of press keywords.
     allow_just_arrangement : bool, optional
         if set to True, the parser accepts strings that are only arrangements, in
         addition to press messages. So, for example, the parser could parse, by default False
@@ -246,6 +245,9 @@ def create_grammar_from_press_keywords(
     """
     if allow_just_arrangement and string_type == "message":
         string_type = "arrangement"
+
+    # The input order or any duplicate elements should not affect the generated grammar
+    keywords = sorted(set(keywords))
 
     full_grammar = create_daide_grammar(
         level=MAX_DAIDE_LEVEL,

--- a/src/daidepp/grammar/grammar_utils.py
+++ b/src/daidepp/grammar/grammar_utils.py
@@ -11,6 +11,7 @@ from daidepp.grammar.grammar import (
     LEVELS,
     TRAIL_TOKEN,
     DAIDELevel,
+    MAX_DAIDE_LEVEL,
     GrammarDict,
 )
 
@@ -247,7 +248,7 @@ def create_grammar_from_press_keywords(
         string_type = "arrangement"
 
     full_grammar = create_daide_grammar(
-        level=DAIDELevel.__args__[-1],
+        level=MAX_DAIDE_LEVEL,
         string_type=string_type,
     )
     current_set = set(LEVEL_0.keys())

--- a/src/daidepp/keywords/daide_object.py
+++ b/src/daidepp/keywords/daide_object.py
@@ -1,12 +1,10 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
-from typing_extensions import get_args
-
 from daidepp.grammar import create_daide_grammar
-from daidepp.grammar.grammar import DAIDELevel
+from daidepp.grammar.grammar import MAX_DAIDE_LEVEL
 
-_grammar = create_daide_grammar(get_args(DAIDELevel)[-1], string_type="all")
+_grammar = create_daide_grammar(MAX_DAIDE_LEVEL, string_type="all")
 
 
 @dataclass(eq=True, frozen=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,11 @@ import pytest
 from typing_extensions import get_args
 
 from daidepp.grammar import create_daide_grammar
-from daidepp.grammar.grammar import DAIDELevel
+from daidepp.grammar.grammar import DAIDELevel, MAX_DAIDE_LEVEL
 from daidepp.keywords.press_keywords import AnyDAIDEToken
 from daidepp.visitor import daide_visitor
 
 # Declared outside of fixture for performance
-MAX_DAIDE_LEVEL = get_args(DAIDELevel)[-1]
 ALL_GRAMMAR = create_daide_grammar(level=MAX_DAIDE_LEVEL, string_type="all")
 
 


### PR DESCRIPTION
I did something similar in #89, but I didn't test keyword-based grammars because I wasn't using them. This carries out a similar change. It also includes two minor commits I already had locally.

## Testing

To test the determinism, I used the Python script `daide_test.py`:

```python
from daidepp import PRP, create_grammar_from_press_keywords, daide_visitor

grammar = create_grammar_from_press_keywords(["PRP", "XDO", "ALY_VSS"], test=True)
msgs = [
    "PRP ( ALY ( ITA TUR ) VSS ( ENG RUS ) )",
    "PRP ( XDO ( ( ENG FLT EDI ) SUP ( ENG AMY LVP ) MTO CLY ) )",
]
for msg in msgs:
    parse_tree = grammar.parse(msg)
    parsed_msg = daide_visitor.visit(parse_tree)
    print(f"parsed_msg = {parsed_msg!r}")
    print(f"type(parsed_msg) = {type(parsed_msg)}")
    assert isinstance(parsed_msg, PRP)
    assert str(parsed_msg) == msg, str(parsed_msg)
```

To repeatedly run the above Python script, I used the following Bash script:

```bash
#!/usr/bin/env bash

for ((i = 0; i < 10; i++)); do
  python daide_test.py
done
```

To test that input order doesn't matter, I used the following code:

```python
from daidepp.grammar.grammar_utils import create_grammar_from_press_keywords

grammar1 = create_grammar_from_press_keywords(
    ["YES", "REJ", "HUH", "PRP", "NAR", "PCE", "ALY_VSS", "XDO", "DMZ", "AND"]
)
grammar2 = create_grammar_from_press_keywords(
    ["ALY_VSS", "AND", "DMZ", "HUH", "NAR", "PCE", "PRP", "REJ", "XDO", "YES"]
)
assert repr(grammar1) == repr(grammar2)
```

To view the grammar being generated, I used the following patch:

```diff
diff --git a/src/daidepp/grammar/grammar_utils.py b/src/daidepp/grammar/grammar_utils.py
index 4bfae0c..25e1717 100644
--- a/src/daidepp/grammar/grammar_utils.py
+++ b/src/daidepp/grammar/grammar_utils.py
@@ -220,6 +220,7 @@ def create_grammar_from_press_keywords(
     keywords: List[PressKeywords],
     allow_just_arrangement: bool = False,
     string_type: Literal["message", "arrangement", "all"] = "message",
+    test: bool = False,
 ) -> DAIDEGrammar:
     """Construct new DAIDE grammar from a list of keywords.

@@ -332,6 +333,13 @@ def create_grammar_from_press_keywords(
         new_grammar_dict.move_to_end("message", last=False)

     new_grammar_str = _create_grammar_str_from_dict(new_grammar_dict, string_type)
+    if test:
+        from pathlib import Path
+        from time import time_ns
+
+        output_dir = Path("grammars")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / f"{time_ns()}.txt").write_text(new_grammar_str)
     new_grammar = DAIDEGrammar(new_grammar_str)
     return new_grammar

```

This specific diff used 4eccbf1684187684f52047f8cb1df9fcdc69a083 as its base.