### PR TITLE
Lower minimum required version of `importlib.metadata`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     parsimonious==0.9.0
-    importlib-metadata>=6.0.0 ; python_version < "3.8"
+    importlib-metadata>=1.4.0 ; python_version < "3.8"
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
I had problems installing a package that required `daidepp` because `daidepp` requires too recent a version of `importlib.metadata`. Commit d31a7d5[^1] added the requirement for `importlib.metadata` with a minimum version of `6.0.0`. The commit was made on 2023-02-08, and `6.0.0` was the latest version available at the time.[^2] However, according to the README,[^3] `1.4.0` was the version used by the Python 3.8 stdlib, so no newer version is needed. I have loosened the requirement accordingly.

[^1]: https://github.com/SHADE-AI/daidepp/commit/d31a7d5b620eec3220631db723957dfb376f1085
[^2]: https://pypi.org/project/importlib-metadata/#history
[^3]: https://pypi.org/project/importlib-metadata/#description