### PR TITLE
Install `typing_extensions` if needed

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -39,6 +39,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install daidepp
         run: |
+          pip install -U pip
           pip install -e .[dev]
       - name: Test
         run: |

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -23,10 +23,10 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # Needed for Python 3.7
     name: Run tests
     env:
-      PYTHON_VERSION: "3.7"
+      PYTHON_VERSION: 3.7.17
     defaults:
       run:
         shell: bash -leo pipefail {0}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -3,18 +3,40 @@ name: test-pr
 on:
   pull_request:
     branches:
-      - "main"
+      - main
+  push:
+    branches:
+      - main
+      - test-ci**
+  workflow_dispatch: # Enable workflow to be run manually
+
+# Disable all access to the GitHub API by default
+# This default can be overridden for individual workflows and jobs
+# Documentation: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
+permissions: {}
+
+# Cancel the currently running CI job if you push a change while CI is running
+# Documentation: https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    name: Run tests
+    env:
+      PYTHON_VERSION: "3.7"
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set Up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install daidepp
         run: |
           pip install -e .[dev]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,17 +21,17 @@ where = src
 
 [options.extras_require]
 dev =
-    black>=22.8.0
-    docformatter==1.4
-    isort>=5.10.1
-    pydocstyle==6.1.1
-    pylint==2.12.2
-    pytest==7.0.0
-    pytest-black==0.3.12
-    pytest-cov==3.0.0
-    pytest-dependency==0.5.1
-    pytest-mypy==0.9.1
-    pytest-timeout==2.1.0
+    black==23.3.0
+    docformatter==1.7.5
+    isort==5.11.5
+    pydocstyle==6.3.0
+    pylint==2.17.7
+    pytest==7.4.4
+    pytest-black==0.6.0
+    pytest-cov==4.1.0
+    pytest-dependency==0.6.0
+    pytest-mypy==0.10.3
+    pytest-timeout==2.3.1
 
 [isort]
 multi_line_output = 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ python_requires = >=3.7
 install_requires =
     parsimonious==0.9.0
     importlib-metadata>=1.4.0 ; python_version < "3.8"
+    typing_extensions>=3.10.0.0 ; python_version < "3.8"
 
 [options.packages.find]
 where = src

--- a/src/daidepp/constants.py
+++ b/src/daidepp/constants.py
@@ -1,4 +1,7 @@
-from typing_extensions import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 Power = Literal["AUS", "ENG", "FRA", "GER", "ITA", "RUS", "TUR"]
 UnitType = Literal["AMY", "FLT"]

--- a/src/daidepp/grammar/grammar.py
+++ b/src/daidepp/grammar/grammar.py
@@ -5,9 +5,13 @@ For now this grammar assumes NO PDA games
 from __future__ import annotations
 
 from typing import Dict, Tuple
-from typing_extensions import get_args
 
-from typing_extensions import Literal
+try:
+    from typing import Literal
+    from typing import get_args
+except ImportError:
+    from typing_extensions import Literal
+    from typing_extensions import get_args
 
 DAIDELevel = Literal[
     0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160

--- a/src/daidepp/grammar/grammar.py
+++ b/src/daidepp/grammar/grammar.py
@@ -7,11 +7,9 @@ from __future__ import annotations
 from typing import Dict, Tuple
 
 try:
-    from typing import Literal
-    from typing import get_args
+    from typing import Literal, get_args
 except ImportError:
-    from typing_extensions import Literal
-    from typing_extensions import get_args
+    from typing_extensions import Literal, get_args
 
 DAIDELevel = Literal[
     0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160

--- a/src/daidepp/grammar/grammar_utils.py
+++ b/src/daidepp/grammar/grammar_utils.py
@@ -3,7 +3,11 @@ from collections import OrderedDict, defaultdict
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 from parsimonious.grammar import Grammar
-from typing_extensions import Literal
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from daidepp.constants import PressKeywords
 from daidepp.grammar.grammar import (

--- a/src/daidepp/keywords/base_keywords.py
+++ b/src/daidepp/keywords/base_keywords.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
-from typing_extensions import get_args
+try:
+    from typing import get_args
+except ImportError:
+    from typing_extensions import get_args
 
 from daidepp.constants import *
 from daidepp.keywords.daide_object import _DAIDEObject

--- a/src/daidepp/visitor.py
+++ b/src/daidepp/visitor.py
@@ -2,7 +2,11 @@ import logging
 from typing import Any
 
 from parsimonious.nodes import Node, NodeVisitor
-from typing_extensions import get_args
+
+try:
+    from typing import get_args
+except ImportError:
+    from typing_extensions import get_args
 
 from daidepp.constants import ProvinceNoCoast
 from daidepp.keywords.base_keywords import *

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
 import pytest
-from typing_extensions import get_args
+
+try:
+    from typing import get_args
+except ImportError:
+    from typing_extensions import get_args
 
 from daidepp.grammar import create_daide_grammar
 from daidepp.grammar.grammar import DAIDELevel, MAX_DAIDE_LEVEL


### PR DESCRIPTION
I discovered a bug where importing from `typing_extensions` would fail because it's not listed as a dependency. Until now, I've always had `typing_extensions` installed as a dependency of another package, so it took a while to encounter this particular bug.

As part of this PR, I fixed the test setup so I could verify my changes don't break anything.