### PR TITLE
Fix `update-version.yml`

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -8,8 +8,8 @@ jobs:
   update_version:
     runs-on: ubuntu-22.04 # Needed for Python 3.7
     steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2.11.1
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3.0.2
         id: filter
         with:
           filters: |

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update_version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # Needed for Python 3.7
     steps:
       - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2.11.1


### PR DESCRIPTION
The CI job failed when merging #98 because `ubuntu-latest` changed. This workflow is a lot harder to test, but I encountered and fix the same error message in the same way on my previous PR.